### PR TITLE
fix: missing MARTe2Application in import

### DIFF
--- a/martepy/marte2/__init__.py
+++ b/martepy/marte2/__init__.py
@@ -4,6 +4,7 @@ from martepy.marte2.gam import MARTe2GAM
 from martepy.marte2.datasources import *
 from martepy.marte2.gams import *
 from martepy.marte2.objects import *
+from martepy.marte2.generic_application import MARTe2Application
 
 __all__ = [
     "MARTe2GAM",


### PR DESCRIPTION
Fixing missing `MARTe2Application` importing. (solving #1)