### PR TITLE
Fix examples

### DIFF
--- a/examples/state_machine_http.py
+++ b/examples/state_machine_http.py
@@ -72,13 +72,13 @@ app.add(functions = functions)
 app.add(states = [
     MARTe2RealTimeState(
         configuration_name = '+Running',
-        threads = [
+        threads = MARTe2ReferenceContainer("Threads", [
             MARTe2RealTimeThread(
                 configuration_name = '+Thread0',
                 cpu_mask = int(cpu_thread_gen(1), 16),
                 functions = functions,
             ),
-        ],
+        ]),
     ),
 ])
 
@@ -131,7 +131,7 @@ startmessages = [prepare] + [MARTe2Message("+StartNextStateExecutionMsg","App","
 
 ''' Note the below is necessary for the HTTPService to be running if you are using one. '''
 
-startmessages += [MARTe2Message("+StartHttpService", "WebService", "Start",None,"")]
+startmessages += [MARTe2Message("+StartHttpService", "WebService", "Start",MARTe2ConfigurationDatabase(),"")]
 event = MARTe2StateMachineEvent('+START',"RUNNING","ERROR",0,startmessages)
 
 currentstate = MARTe2ReferenceContainer("+INITIALISING",[event])
@@ -173,7 +173,6 @@ app.add(externals=[statemachine])
 app.add(states = [
     MARTe2RealTimeState(
         configuration_name = '+ErrorState',
-        threads = [],
     ),
 ])
 

--- a/examples/state_machine_http.py
+++ b/examples/state_machine_http.py
@@ -2,7 +2,6 @@
 import os
 
 from martepy.marte2 import (
-    MARTe2Application,
     MARTe2RealTimeThread,
     MARTe2RealTimeState,
     MARTe2GAMScheduler,
@@ -26,6 +25,8 @@ from martepy.marte2.datasources import (
     LoggerDataSource,
     TimingDataSource
 )
+
+from martepy.marte2.generic_application import MARTe2Application
 
 CPU_OFFSET_FROM_ONE = 0  # 0 to start at cpu 1
 def cpu_thread_gen(x):

--- a/examples/timer_logger.py
+++ b/examples/timer_logger.py
@@ -15,6 +15,7 @@ from martepy.marte2.datasources import (
     LoggerDataSource,
     TimingDataSource
 )
+from martepy.marte2.objects.referencecontainer import MARTe2ReferenceContainer
 
 CPU_OFFSET_FROM_ONE = 0  # 0 to start at cpu 1
 def cpu_thread_gen(x):
@@ -61,13 +62,13 @@ app.add(functions = functions)
 app.add(states = [
     MARTe2RealTimeState(
         configuration_name = '+Running',
-        threads = [
+        threads = MARTe2ReferenceContainer("Threads", objects=[
             MARTe2RealTimeThread(
                 configuration_name = '+Thread0',
                 cpu_mask = int(cpu_thread_gen(1), 16),
                 functions = functions,
             ),
-        ],
+        ]),
     ),
 ])
 

--- a/examples/timer_logger.py
+++ b/examples/timer_logger.py
@@ -1,6 +1,5 @@
 
 from martepy.marte2 import (
-    MARTe2Application,
     MARTe2RealTimeThread,
     MARTe2RealTimeState,
     MARTe2GAMScheduler
@@ -16,6 +15,8 @@ from martepy.marte2.datasources import (
     TimingDataSource
 )
 from martepy.marte2.objects.referencecontainer import MARTe2ReferenceContainer
+
+from martepy.marte2.generic_application import MARTe2Application
 
 CPU_OFFSET_FROM_ONE = 0  # 0 to start at cpu 1
 def cpu_thread_gen(x):

--- a/examples/water_tank.py
+++ b/examples/water_tank.py
@@ -1,6 +1,5 @@
 
 from martepy.marte2 import (
-    MARTe2Application,
     MARTe2RealTimeThread,
     MARTe2RealTimeState,
     MARTe2GAMScheduler
@@ -20,6 +19,8 @@ from martepy.marte2.datasources import (
     GAMDataSource
 )
 from martepy.marte2.objects.referencecontainer import MARTe2ReferenceContainer
+
+from martepy.marte2.generic_application import MARTe2Application
 
 CPU_OFFSET_FROM_ONE = 0  # 0 to start at cpu 1
 def cpu_thread_gen(x):

--- a/examples/water_tank.py
+++ b/examples/water_tank.py
@@ -19,6 +19,7 @@ from martepy.marte2.datasources import (
     FileReader,
     GAMDataSource
 )
+from martepy.marte2.objects.referencecontainer import MARTe2ReferenceContainer
 
 CPU_OFFSET_FROM_ONE = 0  # 0 to start at cpu 1
 def cpu_thread_gen(x):
@@ -91,13 +92,13 @@ app.add(functions=[IOGAM('+Timer', input_signals, output_signals)])
 app.add(states=[
     MARTe2RealTimeState(
         configuration_name='+Running',
-        threads=[
+        threads=MARTe2ReferenceContainer("Threads", objects=[
             MARTe2RealTimeThread(
                 configuration_name='+Thread0',
                 cpu_mask=16,
                 functions=app.functions,
             ),
-        ],
+        ]),
     ),
 ])
 

--- a/martepy/marte2/__init__.py
+++ b/martepy/marte2/__init__.py
@@ -4,7 +4,6 @@ from martepy.marte2.gam import MARTe2GAM
 from martepy.marte2.datasources import *
 from martepy.marte2.gams import *
 from martepy.marte2.objects import *
-from martepy.marte2.generic_application import MARTe2Application
 
 __all__ = [
     "MARTe2GAM",

--- a/martepy/marte2/__init__.py
+++ b/martepy/marte2/__init__.py
@@ -4,6 +4,7 @@ from martepy.marte2.gam import MARTe2GAM
 from martepy.marte2.datasources import *
 from martepy.marte2.gams import *
 from martepy.marte2.objects import *
+from martepy.marte2.generic_application import MARTe2Application
 
 __all__ = [
     "MARTe2GAM",


### PR DESCRIPTION
Examples were broken in my configuration, as the `threads` of the application states were defined as list instead of `MARTe2ReferenceContainer`.

As well in the `state_machine_http.py` a message were defined with a `None` argument that was not matching the library definition.

This solve #3 